### PR TITLE
Check for hash and remove

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,9 @@ module.exports = (job, settings, options, type) => {
   return new Promise((resolve, reject) => {
     options.layers.forEach(asset => {
       const index = job.assets.findIndex(x => x.layerName == asset);
-      const color = hexToRgb(job.assets[index].value);
+      const color_string = getColorValue(job.assets[index].value)
+      const color = hexToRgb(color_string);
+
 
       job.assets[index].value = color;
       settings.logger.log(
@@ -27,4 +29,12 @@ function hexToRgb(hex) {
         1
       ]
     : null;
+}
+
+function getColorValue(colorStr){
+  if(!colorStr.startsWith('#')){
+    return colorStr
+  }
+  let editedClr = colorStr.slice(1)
+  return editedClr
 }


### PR DESCRIPTION
A small update where the user can pass a hex color with a hash and then the app will remove the # before converting to rgb